### PR TITLE
Contact Sheet View and raw-image changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,10 @@ Other parameters of the `eb init` to be aware of are:
 * Enable ssh access (if prompted)
 
 With the eb client configured, we can now deploy the application to AWS EB with the following. Ensure all changes are committed.
+Provide an environment name if no default environment has been configured.
 
 ```
-scripts/eb-deploy.pl
+scripts/eb-deploy.pl [environment-name]
 ```
 
 

--- a/lambda/s3-image-conversion/package-lock.json
+++ b/lambda/s3-image-conversion/package-lock.json
@@ -605,9 +605,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.397.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.397.0.tgz",
-      "integrity": "sha512-Yxt/iL8h1hNkCsBrgjZICnaIyT+q2xR9HNMii1sibmm8iIAg7Gcz/xELNgBEdGos2sWhcgYQVsp6ePbaMgpiKQ==",
+      "version": "2.446.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.446.0.tgz",
+      "integrity": "sha512-xZ+KrHRrQWZLt/1NZ37pzkRbA1rDfryqvcBw5HanmHfO2d2dJJDzow/dfndd/dJyUVc3VvBLPZRW+ZVeFiLw1w==",
       "requires": {
         "buffer": "4.9.1",
         "events": "1.1.1",
@@ -970,7 +970,7 @@
       "dev": true,
       "requires": {
         "async": "2.6.0",
-        "aws-sdk": "2.397.0",
+        "aws-sdk": "2.446.0",
         "body-parser": "1.18.3",
         "chalk": "2.4.1",
         "commander": "2.19.0",
@@ -997,14 +997,6 @@
           "integrity": "sha1-Zyj8BFnEUNeWqZwxg3VpvfZy1yg=",
           "dev": true
         }
-      }
-    },
-    "bindings": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.4.0.tgz",
-      "integrity": "sha512-7znEVX22Djn+nYjxCWKDne0RRloa9XfYa84yk3s+HkE3LpDYZmhArYr9O9huBoHY3/oXispx5LorIX7Sl2CgSQ==",
-      "requires": {
-        "file-uri-to-path": "1.0.0"
       }
     },
     "bl": {
@@ -1418,15 +1410,6 @@
       "requires": {
         "map-visit": "1.0.0",
         "object-visit": "1.0.1"
-      }
-    },
-    "color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.1.0.tgz",
-      "integrity": "sha512-CwyopLkuRYO5ei2EpzpIh6LqJMt6Mt+jZhO5VI5f/wJLZriXQE32/SSqzmrh+QB+AZT81Cj8yv+7zwToW8ahZg==",
-      "requires": {
-        "color-convert": "1.9.3",
-        "color-string": "1.5.3"
       }
     },
     "color-convert": {
@@ -2167,6 +2150,11 @@
         "fill-range": "2.2.4"
       }
     },
+    "expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
+    },
     "expect": {
       "version": "22.4.3",
       "resolved": "http://registry.npmjs.org/expect/-/expect-22.4.3.tgz",
@@ -2297,11 +2285,6 @@
       "requires": {
         "bser": "2.0.0"
       }
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -4981,14 +4964,6 @@
         }
       }
     },
-    "node-abi": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.5.0.tgz",
-      "integrity": "sha512-9g2twBGSP6wIR5PW7tXvAWnEWKJDH/VskdXp168xsw9VVxpEGov8K4jsP4/VeoC7b2ZAyzckvMCuQuQlw44lXg==",
-      "requires": {
-        "semver": "5.6.0"
-      }
-    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -5467,6 +5442,49 @@
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
+    },
+    "prebuild-install": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.0.tgz",
+      "integrity": "sha512-aaLVANlj4HgZweKttFNUVNRxDukytuIuxeK2boIMHjagNJCiVKWFsKF4tCE3ql3GbrD2tExPQ7/pwtEJcHNZeg==",
+      "requires": {
+        "detect-libc": "1.0.3",
+        "expand-template": "2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "napi-build-utils": "1.0.1",
+        "node-abi": "2.8.0",
+        "noop-logger": "0.1.1",
+        "npmlog": "4.1.2",
+        "os-homedir": "1.0.2",
+        "pump": "2.0.1",
+        "rc": "1.2.8",
+        "simple-get": "2.8.1",
+        "tar-fs": "1.16.3",
+        "tunnel-agent": "0.6.0",
+        "which-pm-runs": "1.0.0"
+      },
+      "dependencies": {
+        "node-abi": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.8.0.tgz",
+          "integrity": "sha512-1/aa2clS0pue0HjckL62CsbhWWU35HARvBDXcJtYKbYR7LnIutmpxmXbuDMV9kEviD2lP/wACOgWmmwljghHyQ==",
+          "requires": {
+            "semver": "5.6.0"
+          }
+        },
+        "simple-get": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
+          "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
+          "requires": {
+            "decompress-response": "3.3.0",
+            "once": "1.4.0",
+            "simple-concat": "1.0.0"
+          }
+        }
+      }
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -6279,67 +6297,40 @@
       "dev": true
     },
     "sharp": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.21.3.tgz",
-      "integrity": "sha512-5qZk8r+YgfyztLEKkNez20Wynq/Uh1oNyP5T/3gTYwt2lBYGs9iDs5m0yVsZEPm8eVBbAJhS08J1wp/g+Ai1Qw==",
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.22.1.tgz",
+      "integrity": "sha512-lXzSk/FL5b/MpWrT1pQZneKe25stVjEbl6uhhJcTULm7PhmJgKKRbTDM/vtjyUuC/RLqL2PRyC4rpKwbv3soEw==",
       "requires": {
-        "bindings": "1.4.0",
-        "color": "3.1.0",
+        "color": "3.1.1",
         "detect-libc": "1.0.3",
         "fs-copy-file-sync": "1.1.1",
-        "nan": "2.12.1",
+        "nan": "2.13.2",
         "npmlog": "4.1.2",
-        "prebuild-install": "5.2.3",
-        "semver": "5.6.0",
+        "prebuild-install": "5.3.0",
+        "semver": "6.0.0",
         "simple-get": "3.0.3",
         "tar": "4.4.8",
         "tunnel-agent": "0.6.0"
       },
       "dependencies": {
-        "expand-template": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-          "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
+        "color": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/color/-/color-3.1.1.tgz",
+          "integrity": "sha512-PvUltIXRjehRKPSy89VnDWFKY58xyhTLyxIg21vwQBI6qLwZNPmC8k3C1uytIgFKEpOIzN4y32iPm8231zFHIg==",
+          "requires": {
+            "color-convert": "1.9.3",
+            "color-string": "1.5.3"
+          }
         },
         "nan": {
-          "version": "2.12.1",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
-          "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
+          "version": "2.13.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+          "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
         },
-        "prebuild-install": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.2.3.tgz",
-          "integrity": "sha512-sdijGV8EkK244XbYJLRhOLiHj9QZKUaYW6uDotEPpRGrC5FUXFr6mZhGHr9NjhU0MISI+JSqZ0geVZMs2kIDRQ==",
-          "requires": {
-            "detect-libc": "1.0.3",
-            "expand-template": "2.0.3",
-            "github-from-package": "0.0.0",
-            "minimist": "1.2.0",
-            "mkdirp": "0.5.1",
-            "napi-build-utils": "1.0.1",
-            "node-abi": "2.5.0",
-            "noop-logger": "0.1.1",
-            "npmlog": "4.1.2",
-            "os-homedir": "1.0.2",
-            "pump": "2.0.1",
-            "rc": "1.2.8",
-            "simple-get": "2.8.1",
-            "tar-fs": "1.16.3",
-            "tunnel-agent": "0.6.0",
-            "which-pm-runs": "1.0.0"
-          },
-          "dependencies": {
-            "simple-get": {
-              "version": "2.8.1",
-              "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
-              "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
-              "requires": {
-                "decompress-response": "3.3.0",
-                "once": "1.4.0",
-                "simple-concat": "1.0.0"
-              }
-            }
-          }
+        "semver": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
+          "integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ=="
         }
       }
     },
@@ -7295,7 +7286,7 @@
       "integrity": "sha1-jbfsq0cmdWlizJQuhXHl//1SdCI=",
       "dev": true,
       "requires": {
-        "aws-sdk": "2.397.0",
+        "aws-sdk": "2.446.0",
         "lodash": "4.17.10",
         "nock": "9.6.1",
         "uuid": "3.2.1",

--- a/lambda/s3-image-conversion/package.json
+++ b/lambda/s3-image-conversion/package.json
@@ -9,9 +9,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "aws-sdk": "^2.395.0",
+    "aws-sdk": "^2.446.0",
     "dependencies": "0.0.1",
-    "sharp": "^0.21.3"
+    "sharp": "^0.22.1"
   },
   "devDependencies": {
     "bespoken-tools": "^2.1.1"

--- a/project.clj
+++ b/project.clj
@@ -63,7 +63,8 @@
   :clean-targets ^{:protect false} ["resources/public/js/compiled" "target" "test/js"]
 
   :profiles
-    {:dbmgmt {:dependencies [[org.clojure/tools.nrepl "0.2.13"]]}
+    {;; The dbmgmt profile is used from a repl to interact with DynamoDB
+     :dbmgmt {:dependencies [[org.clojure/tools.nrepl "0.2.13"]]}
 
      :dev
        {:dependencies [[binaryage/devtools "0.9.10"]]

--- a/resources/public/css/helodali.css
+++ b/resources/public/css/helodali.css
@@ -57,6 +57,10 @@ pre {
   object-fit: none;
 }
 
+.contact-sheet-element {
+  margin: 10px;
+}
+
 .login-page {
   background-image:url("/image-assets/file-cabinet.png"), linear-gradient(#e4e0ba, #f7d9aa);
   background-position: top;

--- a/scripts/eb-deploy.pl
+++ b/scripts/eb-deploy.pl
@@ -43,15 +43,15 @@ if (@ARGV and $ARGV[0] =~ /--ignore-changes/i) {
     }
 }
 
+my $env = "";
+(@ARGV == 1) and $env = $ARGV[0];
+
 # Perform an eb status
-print qx(eb status);
+print qx(eb status $env);
 if ($? != 0) {
     printError("Unable to execute eb status: $!\n");
     exit 1;
 };
-
-my $env = "";
-(@ARGV == 1) and $env = $ARGV[0];
 
 print "Continue with deploy (y|n)? [y] ";
 my $response = <STDIN>;

--- a/src/clj/helodali/cognito.clj
+++ b/src/clj/helodali/cognito.clj
@@ -19,8 +19,8 @@
                      (System/getProperty "HD_COGNITO_REDIRECT_URI"))})
 
 (def options {:timeout 900  ;; ms
-              :debug true
-              :debug-body true
+              ;:debug true
+              ;:debug-body true
               :basic-auth [(:id client) (:secret client)]
               :as :auto  ;; Try to automatically coerce the output based on the content-type
               :headers {:Accept "application/json"}})

--- a/src/clj/helodali/db.clj
+++ b/src/clj/helodali/db.clj
@@ -426,7 +426,9 @@
       session
       {})))
 
-;; Maintenance functions
+;;
+;; Maintenance functions not invoked by the helodali server-side
+;;
 
 (defn create-table
   [name]

--- a/src/clj/helodali/instagram.clj
+++ b/src/clj/helodali/instagram.clj
@@ -91,7 +91,6 @@
             user-artwork (query-by-uref :artwork uref {:proj-expr "#uuid, #instagramMediaRef"
                                                        :expr-attr-names {"#uuid" "uuid" "#instagramMediaRef" "instagram-media-ref"}})
             user-artwork-lookup (by-instagram-id user-artwork)]
-        (pprint (str "user-artwork-lookup: " user-artwork-lookup))
         (map (partial convert-to-item user-artwork-lookup) media)))))
 
 (defn refresh-instagram

--- a/src/cljs/helodali/db.cljs
+++ b/src/cljs/helodali/db.cljs
@@ -187,7 +187,7 @@
    :ui-defaults ui-defaults
    :view :artwork
    :static-page nil
-   :display-type :contact-sheet ;; Can be :new-item :contact-sheet :row :list :single-item :instagram
+   :display-type :summary-view ;; Can be :new-item :summary-view :contact-sheet :row :list :single-item :instagram
    :single-item-uuid nil ;; Used to defined which entity is being viewed in detail
    :messages {}
    :search-pattern nil
@@ -233,6 +233,15 @@
 (defn default-view-for-type
   [type]
   (condp = type
-     :artwork :contact-sheet
+     :artwork :summary-view
      :list))
+
+(defn s3-key-for-bucket
+  "Given a s3 bucket name, return the associated map key that defines the s3
+   objectKey. E.g. resized image maps and documents use :key while
+   the raw image key on helodali-raw-images is defined in :raw-key"
+  [bucket]
+  (condp = bucket
+    "helodali-raw-images" :raw-key
+    :key))
 

--- a/src/cljs/helodali/spec.cljs
+++ b/src/cljs/helodali/spec.cljs
@@ -50,7 +50,7 @@
 (s/def ::format (s/nilable string?))
 (s/def ::metadata (s/keys :opt-un [::size ::space ::height ::width ::density ::format]))
 (s/def ::image (s/keys :req-un [::uuid]
-                       :opt-un [::key ::filename ::processing ::signed-thumb-url ::signed-thumb-url-expiration-time
+                       :opt-un [::key ::raw-key ::filename ::processing ::signed-thumb-url ::signed-thumb-url-expiration-time
                                 ::signed-raw-url ::signed-raw-url-expiration-time ::signed-image-url
                                 ::signed-image-url-expiration-time ::metadata]))
 (s/def ::images (s/coll-of ::image))
@@ -219,7 +219,7 @@
 (s/def ::view #{:show-login :artwork :contacts :exhibitions :documents :purchases :press :profile
                 :search-results :account :pages :static-page :expenses :landing})
 (s/def ::static-page (s/nilable #{:privacy-policy}))
-(s/def ::display-type #{:contact-sheet :single-item :new-item :list :row :instagram})
+(s/def ::display-type #{:summary-view :contact-sheet :single-item :new-item :list :row :instagram})
 (s/def ::contacts (s/every-kv ::id ::contact))
 (s/def ::expenses (s/every-kv ::id ::expense))
 (s/def ::exhibitions (s/every-kv ::id ::exhibition))

--- a/src/cljs/helodali/subs.cljs
+++ b/src/cljs/helodali/subs.cljs
@@ -112,7 +112,7 @@
       (sort #(sort-by-key-then-created kw reverse? (:purchase %1) (:purchase %2)) (filter predicate purchases)))))
 
 (def various-keys-to-filter-out-of-search-results
-  #{:key :signed-thumb-url :signed-thumb-url-expiration-time :signed-raw-url :signed-raw-url-expiration-time
+  #{:key :raw-key :signed-thumb-url :signed-thumb-url-expiration-time :signed-raw-url :signed-raw-url-expiration-time
     :uuid :uref})
 
 (defn- tagged-match


### PR DESCRIPTION

- Update the artwork item image map to include a :raw-key in addition to :key, where :raw-key points to the s3 objectKey in helodali-raw-images and :key points to all resized images in helodali-images/thumbs/etc. Document items are unaffected, still using :key.
- Replace row-view with a proper contact sheet view and rename the original default view to summary-view.