### PR TITLE
Tweaks and bug fixes

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -30,7 +30,7 @@
         yogthos/config {:mvn/version "1.1.1" :exclusions [org.clojure/tools.logging]}
         clj-jwt {:mvn/version "0.1.1"}
         buddy/buddy-core {:mvn/version "1.5.0"}
-        org.clojars.bskinny/aws-sdk-js {:mvn/version "2.394.0-1"} ;; This is a local build of aws-sdk-js}
+        org.clojars.bskinny/aws-sdk-js {:mvn/version "2.527.0-1"} ;; This is a local build of aws-sdk-js}
         ring/ring-defaults {:mvn/version "0.3.2"}
         ring-middleware-format {:mvn/version "0.7.4"}
         ring-logger {:mvn/version "0.7.8"}

--- a/docs/CLJSJS.md
+++ b/docs/CLJSJS.md
@@ -27,6 +27,7 @@ AWS.CognitoIdentityCredentials.prototype = {
   "cacheId": function () {},
   "clearCachedId": function () {},
   "clearIdOnNotAuthorized": function () {},
+  "coalesceRefresh": function () {},
   "constructor": function () {},
   "createClients": function () {},
   "expiryWindow": function () {},
@@ -36,6 +37,7 @@ AWS.CognitoIdentityCredentials.prototype = {
   "getId": function () {},
   "getPromise": function () {},
   "getStorage": function () {},
+  "load": function () {},
   "loadCachedId": function () {},
   "loadCredentials": function () {},
   "localStorageKey": function () {},
@@ -45,22 +47,21 @@ AWS.CognitoIdentityCredentials.prototype = {
   "setStorage": function () {},
   "storage": function () {}
 };
-
 ```
 
 1. Updated build.boot
 ```clojure
 (set-env!
   :resource-paths #{"resources"}
-  :dependencies '[[cljsjs/boot-cljsjs "0.10.3" :scope "test"]])
+  :dependencies '[[cljsjs/boot-cljsjs "0.10.4" :scope "test"]])
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 ;; Example Build and Deploy to Clojars:
 ;; boot package target
-;; boot push --repo clojars --file target/aws-sdk-js-2.394.0-1.jar
+;; boot push --repo clojars --file target/aws-sdk-js-2.527.0-1.jar
 
-(def +lib-version+ "2.394.0")
+(def +lib-version+ "2.527.0")
 (def +version+ (str +lib-version+ "-1"))
 
 ;; The clojars username and password values will be pulled from .lein/credentials (see .boot/profile.boot)
@@ -90,7 +91,10 @@ AWS.CognitoIdentityCredentials.prototype = {
    (jar)
    (validate-checksums)))
 ```
-1. Update the version number in aws-sdk-js/build.boot, e.g. _2.394.0-1_.
+1. Update the externs. You can generate a new (humongous) ext.js using this [generator](http://jmmk.github.io/javascript-externs-generator) with the 
+input of https://sdk.amazonaws.com/js/aws-sdk-2.421.0.min.js (version number corrected) and then parse out the needed externs
+1. Update the version number in aws-sdk-js/build.boot, e.g. _2.527.0-1_.
+1. Comment out the (set-env! :repositories ...) in `build.boot` - FIXME: This needs to be present for the later invocation of `boot push`
 1. `boot package target`
 1. Configure authentication to clojars
 1. `boot push --repo clojars --file target/aws-sdk-js-2.394.0-1.jar`

--- a/project.clj
+++ b/project.clj
@@ -29,7 +29,7 @@
                  [yogthos/config "1.1.1"]
                  [clj-jwt "0.1.1"]
                  [buddy/buddy-core "1.5.0"]
-                 [org.clojars.bskinny/aws-sdk-js "2.394.0-1"]  ;; This is a local build of aws-sdk-js for now (see README).
+                 [org.clojars.bskinny/aws-sdk-js "2.527.0-1"]  ;; This is a local build of aws-sdk-js for now (see README).
                  [ring/ring-defaults "0.3.2"]
                  [ring-middleware-format "0.7.4"]
                  [ring-logger "0.7.8"]

--- a/src/cljs/helodali/db.cljs
+++ b/src/cljs/helodali/db.cljs
@@ -41,8 +41,7 @@
    :role :person ;; Can also be :agent :company :dealer :gallery :institution
    :notes nil
    :associated-documents #{}
-   :editing false
-   :expanded false})
+   :editing false})
 
 (defn default-expense
   []
@@ -52,8 +51,7 @@
    :expense-type :materials
    :notes nil
    :price 0
-   :editing false
-   :expanded false})
+   :editing false})
 
 (defn default-document
   []
@@ -67,8 +65,7 @@
    :filename nil
    :size 0
    :notes nil
-   :editing false
-   :expanded false})
+   :editing false})
 
 (defn default-press
   []
@@ -169,7 +166,6 @@
    ; :square {:category :artwork}
 
    ;; The following are housekeeping attributes for the web client
-   :expanded false
    :editing false})
 
 

--- a/src/cljs/helodali/spec.cljs
+++ b/src/cljs/helodali/spec.cljs
@@ -7,9 +7,8 @@
 ;; Common types
 (s/def ::id int?)
 (s/def ::uuid string?)
-(s/def ::title (s/nilable string?))
+(s/def ::title (s/and string? #(< 0 (count %))))
 (s/def ::editing boolean?)
-(s/def ::expanded boolean?)
 (s/def ::description (s/nilable string?))
 (s/def ::notes (s/nilable string?))
 (s/def ::date #(instance? goog.date.Date %)) ;; a DateTime, down to the day
@@ -21,7 +20,7 @@
 (s/def ::associated-documents (s/nilable (s/coll-of ::uuid)))
 (s/def ::associated-press (s/nilable (s/coll-of ::uuid)))
 (s/def ::processing (s/nilable boolean?))
-(s/def ::name string?)
+(s/def ::name (s/and string? #(< 0 (count %))))
 
 ;; Instagram items
 (s/def ::instagram-id (s/nilable string?))
@@ -95,7 +94,7 @@
 (s/def ::artwork-item (s/keys :req-un [::uuid ::title ::year ::images ::medium ::created
                                        ::type ::dimensions ::series ::status]
                               :opt-un [::description ::editions ::condition ::style ::associated-documents ::purchases
-                                       ::list-price ::current-location ::expanded ::editing ::exhibition-history
+                                       ::list-price ::current-location ::editing ::exhibition-history
                                        ::instagram-media-ref ::sync-with-instagram]))
 (s/def ::artwork (s/every-kv ::id ::artwork-item))
 (s/def ::artwork-defaults (s/keys :req-un [::type ::dimensions ::medium]))
@@ -124,8 +123,8 @@
 (s/def ::volume (s/nilable string?))
 (s/def ::page-numbers (s/nilable string?))  ;; e.g. 55-60
 (s/def ::publication-date (s/nilable ::date))
-(s/def ::press-ref (s/keys :req-un [::uuid]
-                           :opt-un [::title ::author-first-name ::author-last-name ::publication ::url ::volume
+(s/def ::press-ref (s/keys :req-un [::uuid ::title]
+                           :opt-un [::author-first-name ::author-last-name ::publication ::url ::volume
                                     ::publication-date ::page-numbers ::include-in-cv ::notes ::associated-documents]))
 
 ;; Expenses
@@ -148,8 +147,8 @@
                                      ::images ::associated-documents ::associated-press]))
 
 ;; Document
-(s/def ::document (s/keys :req-un [::uuid ::created]
-                          :opt-un [::notes ::size ::processing ::filename ::last-modified ::title
+(s/def ::document (s/keys :req-un [::uuid ::created ::title]
+                          :opt-un [::notes ::size ::processing ::filename ::last-modified
                                    ::key ::signed-raw-url ::signed-raw-url-expiration-time]))
 
 ;; Public Pages

--- a/src/cljs/helodali/views.cljs
+++ b/src/cljs/helodali/views.cljs
@@ -72,8 +72,7 @@
                                        (route-search %))]
                     [h-box :gap "8px" :justify :around
                       :children [[md-icon-button :md-icon-name "zmdi zmdi-collection-image-o" :size :larger
-                                                 :on-click #(do (dispatch [:sweep-and-set :artwork :expanded false])
-                                                                (route helodali.routes/view {:type (name :artwork)}))]
+                                                 :on-click #(route helodali.routes/view {:type (name :artwork)})]
                                  [re-com/popover-anchor-wrapper :showing? showing-account-popover? :position :below-right
                                    :anchor   [md-icon-button :md-icon-name "zmdi zmdi-account-o" :size :larger :attr {:id :account-button}
                                                     :on-click #(reset! showing-account-popover? true)]

--- a/src/cljs/helodali/views.cljs
+++ b/src/cljs/helodali/views.cljs
@@ -249,7 +249,7 @@
        (and (not @authenticated?) (empty? @access-token) (= @view :static-page))
        ;; Display static html with login header
        [v-box :gap "20px" :width "100%" :height "100%" :margin "0" :justify :between
-          :children [[h-box :align :center :justify :around :children [(our-title @view) (login-button)]]
+          :children [[h-box :align :center :justify :around :class "header" :children [(our-title @view) (login-button)]]
                      [static-pages-view]
                      [footer]]]
 

--- a/src/cljs/helodali/views/documents.cljs
+++ b/src/cljs/helodali/views/documents.cljs
@@ -70,9 +70,10 @@
                                         [button :label "Cancel" :class "btn-default"
                                           :on-click #(dispatch [:cancel-edit-item [:documents id]])]]]
             edit [[h-box :gap "4px" :align :center
-                     :children [[:span.uppercase.light-grey "Title"]
+                     :children [[:span.uppercase.bold "Title"]
                                 [input-text :width "280px" :model (str @title) :style {:border "none"}
                                      :on-change #(dispatch [:set-local-item-val [:documents id :title] %])]]]
+                  [:span.all-small-caps "The document can be uploaded after a title is created."]
                   [v-box :gap "4px" :align :start :justify :start
                      :children [[:span.uppercase.light-grey "Notes"]
                                 [input-textarea :model (str @notes) :width "360px"

--- a/src/cljs/helodali/views/exhibitions.cljs
+++ b/src/cljs/helodali/views/exhibitions.cljs
@@ -63,7 +63,7 @@
         include-in-cv? (subscribe [:item-key :exhibitions id :include-in-cv])
         associated-documents (subscribe [:by-path-and-deref-set-sorted-by [:exhibitions id :associated-documents] :documents (partial sort-by-key-then-created :title false)])
         associated-press (subscribe [:by-path-and-deref-set-sorted-by [:exhibitions id :associated-press] :press (partial sort-by-datetime :publication-date true)])
-        documents (subscribe [:items-vals-with-uuid :documents :title]) ;; TODO: a document may not have a title, resulting in an empty string in the selection list
+        documents (subscribe [:items-vals-with-uuid :documents :title])
         press (subscribe [:items-vals-with-uuid :press :title])
         kind (subscribe [:item-key :exhibitions id :kind])
         notes (subscribe [:item-key :exhibitions id :notes])
@@ -147,12 +147,16 @@
                             :on-change #(dispatch [:set-local-item-val [:exhibitions id :include-in-cv] (not @include-in-cv?)])]
                   [h-box :gap "6px" :align :center
                      :children [[:span.input-label "Press"]
-                                [selection-list :choices (uuid-label-list-to-options @press false) :model (if (empty? @associated-press) #{} (set @associated-press)) ;:height "140px"
-                                       :on-change #(dispatch [:set-local-item-val [:exhibitions id :associated-press] %])]]]
+                                (if (empty? @press)
+                                  [:span.all-small-caps "must first be defined before associating with this exhibition"]
+                                  [selection-list :choices (uuid-label-list-to-options @press false) :model (if (empty? @associated-press) #{} (set @associated-press))
+                                         :on-change #(dispatch [:set-local-item-val [:exhibitions id :associated-press] %])])]]
                   [h-box :gap "6px" :align :center
                      :children [[:span.input-label "Documents"]
-                                [selection-list :choices (uuid-label-list-to-options @documents false) :model (if (empty? @associated-documents) #{} (set @associated-documents)) ;:height "140px"
-                                       :on-change #(dispatch [:set-local-item-val [:exhibitions id :associated-documents] %])]]]
+                                (if (empty? @documents)
+                                  [:span.all-small-caps "must first be defined before associating with this exhibition"]
+                                  [selection-list :choices (uuid-label-list-to-options @documents false) :model (if (empty? @associated-documents) #{} (set @associated-documents))
+                                         :on-change #(dispatch [:set-local-item-val [:exhibitions id :associated-documents] %])])]]
                   [:span.uppercase.light-grey "Notes"]
                   [input-textarea :model (str @notes) :width "360px"
                       :rows 4 :on-change #(dispatch [:set-local-item-val [:exhibitions id :notes] %])]]

--- a/src/cljs/helodali/views/press.cljs
+++ b/src/cljs/helodali/views/press.cljs
@@ -35,7 +35,7 @@
         volume (subscribe [:item-key :press id :volume])
         url (subscribe [:item-key :press id :url])
         associated-documents (subscribe [:by-path-and-deref-set-sorted-by [:press id :associated-documents] :documents (partial sort-by-key-then-created :title false)])
-        documents (subscribe [:items-vals-with-uuid :documents :title]) ;; TODO: a document may not have a title, resulting in an empty string in the selection list
+        documents (subscribe [:items-vals-with-uuid :documents :title])
         publication-date (subscribe [:item-key :press id :publication-date])
         page-numbers (subscribe [:item-key :press id :page-numbers])
         include-in-cv? (subscribe [:item-key :press id :include-in-cv])
@@ -131,8 +131,10 @@
                      :on-change #(dispatch [:set-local-item-val [:press id :include-in-cv] (not @include-in-cv?)])]
                   [h-box :gap "6px" :align :center
                      :children [[:span.input-label "Documents"]
-                                [selection-list :choices (uuid-label-list-to-options @documents false) :model (if (empty? @associated-documents) #{} (set @associated-documents)) ;:height "140px"
-                                       :on-change #(dispatch [:set-local-item-val [:press id :associated-documents] %])]]]
+                                (if (empty? @documents)
+                                  [:span.all-small-caps "must first be defined before associating with this item"]
+                                  [selection-list :choices (uuid-label-list-to-options @documents false) :model (if (empty? @associated-documents) #{} (set @associated-documents)) ;:height "140px"
+                                         :on-change #(dispatch [:set-local-item-val [:press id :associated-documents] %])])]]
                   [:span.uppercase.light-grey "Notes"]
                   [input-textarea :model (str @notes) :width "360px"
                       :rows 4 :on-change #(dispatch [:set-local-item-val [:press id :notes] %])]]]


### PR DESCRIPTION

- Remove the :expanded state of artwork within the summary-view and go straight into the single-item view.
- Fix the inchoate placeholder item spec issue reported in #12 
- Define document title as a required field
- Implement better method for checking expired AWS credentials