### PR TITLE
Adjust contact-view with page size of 100 items

### DIFF
--- a/src/cljs/helodali/db.cljs
+++ b/src/cljs/helodali/db.cljs
@@ -185,6 +185,7 @@
    :static-page nil
    :display-type :summary-view ;; Can be :new-item :summary-view :contact-sheet :row :list :single-item :instagram
    :summary-display-count 10
+   :contact-sheet-display-count 100
    :single-item-uuid nil ;; Used to defined which entity is being viewed in detail
    :messages {}
    :search-pattern nil

--- a/src/cljs/helodali/spec.cljs
+++ b/src/cljs/helodali/spec.cljs
@@ -221,6 +221,7 @@
 (s/def ::static-page (s/nilable #{:privacy-policy}))
 (s/def ::display-type #{:summary-view :contact-sheet :single-item :new-item :list :row :instagram})
 (s/def ::summary-display-count (s/nilable int?))
+(s/def ::contact-sheet-display-count (s/nilable int?))
 (s/def ::contacts (s/every-kv ::id ::contact))
 (s/def ::expenses (s/every-kv ::id ::expense))
 (s/def ::exhibitions (s/every-kv ::id ::exhibition))

--- a/src/cljs/helodali/subs.cljs
+++ b/src/cljs/helodali/subs.cljs
@@ -165,8 +165,9 @@
   "Accumulate matches for given pattern and item, using title-kw as the 'name' of the item."
   [item-type pattern item title-kw]
   (let [results (walk-searcher pattern nil item)]
-    ;; Results can look something like this:
-    ;; ("New3asdsd- that took awhile" [("This took more time to sell than imagined.")])
+    ;; Results can look something like this, searching for the string "some" and finding a couple matches
+    ;; in a particular :contact item's facebook and url fields:
+    ;; ("facebook: something-at-fb" "url: something.com")"
     ;; We assume the flatten function is trustworthy for flattening this.
     {:type item-type :uuid (:uuid item) :title (get item title-kw) :match (flatten results)}))
 
@@ -184,11 +185,12 @@
             pattern (re-pattern (str "(?im).*" (:search-pattern db) ".*"))
             artwork (filter #(not (empty? (:match %))) (map #(search-acc :artwork pattern % :title) (vals (get db :artwork))))
             contacts (filter #(not (empty? (:match %))) (map #(search-acc :contacts pattern % :name) (vals (get db :contacts))))
+            documents (filter #(not (empty? (:match %))) (map #(search-acc :documents pattern % :title) (vals (get db :documents))))
             expenses (filter #(not (empty? (:match %))) (map #(search-acc :expenses pattern % :name) (vals (get db :expenses))))
             exhibitions (filter #(not (empty? (:match %))) (map #(search-acc :exhibitions pattern % :expense-type) (vals (get db :exhibitions))))
             press (filter #(not (empty? (:match %))) (map #(search-acc :press pattern % :title) (vals (get db :press))))
             profile (filter #(not (empty? (:match %))) (list (search-acc :profile pattern (get db :profile) :name)))
-            matches (concat artwork contacts expenses exhibitions press profile)]
+            matches (concat artwork contacts documents expenses exhibitions press profile)]
         (if (= kw :match) ;; Handle the sorting on 'Match' column differently than the others
           (let [reverse (if reverse? -1 1)]
             (sort #(* reverse (compare (first (:match %1)) (first (:match %2)))) matches))


### PR DESCRIPTION
- Limit the initial contact-view display to 100 items with the "more/fewer" controls to increase/decrease the total items to display
- Fix a bug which prevented searching document titles and notes