### PR TITLE
Fix cognito identity

### DIFF
--- a/lambda/s3-image-conversion/scripts/make-zip.sh
+++ b/lambda/s3-image-conversion/scripts/make-zip.sh
@@ -4,6 +4,7 @@ rm -rf node_modules
 docker run -v "$PWD":/var/task lambci/lambda:build-nodejs8.10 npm install
 
 # Create the zip with just index.js and node_modules at the top level.
+rm -f image-conversion.zip
 mkdir zip-contents
 cp index.js zip-contents
 mv node_modules zip-contents

--- a/src/cljs/helodali/db.cljs
+++ b/src/cljs/helodali/db.cljs
@@ -192,6 +192,7 @@
    :sit-and-spin false ;; A directive to show the spinner on the main page
    :initialized? false
    :authenticated? false
+   :cognito-identity-id nil
    :aws-creds nil
    :access-token nil
    :id-token nil

--- a/src/cljs/helodali/spec.cljs
+++ b/src/cljs/helodali/spec.cljs
@@ -211,6 +211,7 @@
 (s/def ::refresh-aws-creds? boolean?)
 (s/def ::do-cognito-logout? boolean?)
 (s/def ::access-token (s/nilable string?))
+(s/def ::cognito-identity-id (s/nilable string?))
 (s/def ::id-token (s/nilable string?))
 (s/def ::userinfo (s/nilable (s/keys :opt-un [::sub]))) ;; From Cognito, no need to spec the complete contents of this map
 (s/def ::csrf-token (s/nilable string?))
@@ -231,7 +232,7 @@
 (s/def ::ui-defaults (s/nilable (s/keys :req-un [::artwork-defaults])))
 (s/def ::messages (s/keys))  ;; The keys for ::messages are mostly random
 (s/def ::db (s/keys :req-un [::view ::display-type ::single-item-uuid ::artwork ::contacts ::exhibitions ::ui-defaults
-                             ::press ::profile ::authenticated? ::initialized? ::access-token ::id-token
+                             ::press ::profile ::authenticated? ::initialized? ::access-token ::id-token ::cognito-identity-id
                              ::userinfo ::search-pattern ::documents ::aws-creds ::refresh-aws-creds? ::account]
                     :opt-un [::messages ::instagram-media ::do-cognito-logout? ::pages]))
 

--- a/src/cljs/helodali/views/artwork.cljs
+++ b/src/cljs/helodali/views/artwork.cljs
@@ -433,8 +433,8 @@
         (when (and (:raw-key image) (or (expired? @raw-expiration) (= "https://aws.amazon.com/s3/" @raw-image-url)))
           (dispatch [:get-signed-url [:artwork id :images 0] "helodali-raw-images" (:raw-key image) :signed-raw-url :signed-raw-url-expiration-time]))
 
-        (pprint (str "Raw image expiration " @raw-expiration " expired? " (expired? @raw-expiration)))
-        (pprint (str "Raw image url: " @raw-image-url))
+        ;(pprint (str "Raw image expiration " @raw-expiration " expired? " (expired? @raw-expiration)))
+        ;(pprint (str "Raw image url: " @raw-image-url))
 
         ;; Base UI on new-item versus single-item versus inline display within :summary-view
         ;; A new-item view does not present the image or edit/delete controls

--- a/src/cljs/helodali/views/documents.cljs
+++ b/src/cljs/helodali/views/documents.cljs
@@ -130,6 +130,7 @@
                                     :children [[popover-tooltip :label "Download document"
                                                   :showing? showing-download-tooltip? :position :below-center
                                                   :anchor [:a {:class "zmdi zmdi-download rc-md-icon-button rc-icon-emphasis"
+                                                               :target "_blank" :rel "noopener noreferrer"
                                                                :on-mouse-over (handler-fn (reset! showing-download-tooltip? true))
                                                                :on-mouse-out  (handler-fn (reset! showing-download-tooltip? false))
                                                                :href @signed-raw-url


### PR DESCRIPTION

- This change is required for proper function of the temporary AWS (web) credentials issued by Cognito. An identity-id is defined by Cognito and stored in the Identity Pool for which can be referenced in ACL via the confusingly-named cognito-identity.amazonaws.com:sub identifier. Indeed, the sub portion of the identifier is what had me using the OIDC sub claim from the id-token.

- One-line fix to properly return 404 Not Found for flagrant GET requests.