### PR TITLE
More IdentityId changes

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -30,7 +30,7 @@
         yogthos/config {:mvn/version "1.1.1" :exclusions [org.clojure/tools.logging]}
         clj-jwt {:mvn/version "0.1.1"}
         buddy/buddy-core {:mvn/version "1.5.0"}
-        org.clojars.bskinny/aws-sdk-js {:mvn/version "2.527.0-1"} ;; This is a local build of aws-sdk-js}
+        org.clojars.bskinny/aws-sdk-js {:mvn/version "2.527.0-2"} ;; This is a local build of aws-sdk-js}
         ring/ring-defaults {:mvn/version "0.3.2"}
         ring-middleware-format {:mvn/version "0.7.4"}
         ring-logger {:mvn/version "0.7.8"}

--- a/project.clj
+++ b/project.clj
@@ -29,7 +29,7 @@
                  [yogthos/config "1.1.1"]
                  [clj-jwt "0.1.1"]
                  [buddy/buddy-core "1.5.0"]
-                 [org.clojars.bskinny/aws-sdk-js "2.527.0-1"]  ;; This is a local build of aws-sdk-js for now (see README).
+                 [org.clojars.bskinny/aws-sdk-js "2.527.0-2"]  ;; This is a local build of aws-sdk-js for now (see README).
                  [ring/ring-defaults "0.3.2"]
                  [ring-middleware-format "0.7.4"]
                  [ring-logger "0.7.8"]

--- a/src/cljs/helodali/events.cljs
+++ b/src/cljs/helodali/events.cljs
@@ -736,7 +736,7 @@
                          (assoc :aws-s3 (js/AWS.S3. (clj->js aws-creds)))
                          (assoc :aws-creds aws-creds))]
       (pprint (str "IdentityId: " cognito-identity-id))
-      ;; Update the database but only update the openid table if the identity-id
+      ;; Update the database but only update the :openid table if the identity-id
       ;; has a value (i.e. don't nil out a non-empty value on the server).
       (if cognito-identity-id
         {:db db-changes :http-xhrio update-identity-req}

--- a/src/cljs/helodali/views.cljs
+++ b/src/cljs/helodali/views.cljs
@@ -227,10 +227,6 @@
                      :Logins {"cognito-idp.us-east-1.amazonaws.com/us-east-1_0cJWyWe5Z" @id-token}}]
          (set! (.-region aws-config) "us-east-1")
          (set! (.-credentials aws-config) (js/AWS.CognitoIdentityCredentials. (clj->js logins)))
-         ;; This clearCachedId and recreation of credentials is a workaround still required as of 06012018
-         ;; and described here:https://github.com/aws/aws-sdk-js/issues/609.
-         ;(.clearCachedId (.-credentials aws-config))
-         ;(set! (.-credentials aws-config) (js/AWS.CognitoIdentityCredentials. (clj->js logins)))
          (.get (.-credentials aws-config) (clj->js (fn [err] (dispatch [:set-aws-credentials (.-credentials js/AWS.config)]))))))
 
      ;;

--- a/src/cljs/helodali/views.cljs
+++ b/src/cljs/helodali/views.cljs
@@ -200,8 +200,10 @@
      ;; Perform whatever dispatching is needed depending on current state
      ;;
      (when @do-cognito-logout?
-       (set! (.. js/window -location -href)
-             (str cognito-base-url "/logout?logout_uri=" origin "/&client_id=" cognito-client-id)))
+       (do
+         (.clearCachedId (.-credentials (.-config js/AWS)))
+         (set! (.. js/window -location -href)
+               (str cognito-base-url "/logout?logout_uri=" origin "/&client_id=" cognito-client-id))))
 
      (when (and (not @authenticated?) (not (empty? @access-token)) (not (empty? @csrf-token)))
        (dispatch [:validate-access-token]))
@@ -227,8 +229,8 @@
          (set! (.-credentials aws-config) (js/AWS.CognitoIdentityCredentials. (clj->js logins)))
          ;; This clearCachedId and recreation of credentials is a workaround still required as of 06012018
          ;; and described here:https://github.com/aws/aws-sdk-js/issues/609.
-         (.clearCachedId (.-credentials aws-config))
-         (set! (.-credentials aws-config) (js/AWS.CognitoIdentityCredentials. (clj->js logins)))
+         ;(.clearCachedId (.-credentials aws-config))
+         ;(set! (.-credentials aws-config) (js/AWS.CognitoIdentityCredentials. (clj->js logins)))
          (.get (.-credentials aws-config) (clj->js (fn [err] (dispatch [:set-aws-credentials (.-credentials js/AWS.config)]))))))
 
      ;;


### PR DESCRIPTION

- Prevent the overwrite of :openid/identity-id with an empty value
- Remove the clearCachedId workaround
- Bump to aws-sdk-js with externs including -identity-id field