### PR TITLE
Remove deprecated Sharp methods; migrate to java-time on the backend

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -8,7 +8,6 @@
         re-frame {:mvn/version "0.10.6"}
         cljs-ajax {:mvn/version "0.8.0"}
         day8.re-frame/http-fx {:mvn/version "0.1.6"}
-        joda-time {:mvn/version "2.10.1"}
         amazonica {:mvn/version "0.3.134" :exclusions [com.amazonaws/aws-java-sdk com.amazonaws/amazon-kinesis-client]}
         com.amazonaws/aws-java-sdk-core {:mvn/version "1.11.452"}
         com.amazonaws/aws-java-sdk-dynamodb {:mvn/version "1.11.452"}
@@ -21,7 +20,7 @@
         org.clojure/core.async {:mvn/version "0.4.474"}
         danlentz/clj-uuid {:mvn/version "0.1.7"}
         com.lucasbradstreet/cljs-uuid-utils {:mvn/version "1.0.2"}
-        clj-time {:mvn/version "0.15.1"}
+        clojure.java-time/clojure.java-time {:mvn/version "0.3.2"}
         com.andrewmcveigh/cljs-time {:mvn/version "0.5.2"}
         re-com {:mvn/version "2.4.0"}
         compojure {:mvn/version "1.6.1"}

--- a/lambda/ribbon-maker/index.js
+++ b/lambda/ribbon-maker/index.js
@@ -62,10 +62,13 @@ function processPrefix(record, callback) {
                 // Calculate the placement of the current tile in the ribbon
 
                 return acc.then(function(data) {
-                    return sharp(overlayResponse.Body).resize(OVERLAY_WIDTH, OVERLAY_HEIGHT).crop(sharp.strategy.entropy).toBuffer().then(function (overlay) {
+                    return sharp(overlayResponse.Body).resize({width: OVERLAY_WIDTH, 
+                                                               height: OVERLAY_HEIGHT, 
+                                                               position: sharp.strategy.entropy})
+                                                      .toBuffer().then(function (overlay) {
                         var left = OVERLAY_WIDTH * (currentIndex % IMAGES_PER_ROW);
                         var top = OVERLAY_HEIGHT * Math.trunc(currentIndex / IMAGES_PER_ROW);
-                        return sharp(data, options).overlayWith(overlay, {left: left, top: top}).raw().toBuffer();
+                        return sharp(data, options).composite([{input: overlay, left: left, top: top}]).raw().toBuffer();
                     }).catch((err) => {
                         console.log('Error adding image to ribbon: ' + err);
                       });

--- a/lambda/ribbon-maker/package-lock.json
+++ b/lambda/ribbon-maker/package-lock.json
@@ -1910,14 +1910,6 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
-    "decompress-response": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-      "requires": {
-        "mimic-response": "1.0.1"
-      }
-    },
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
@@ -5068,11 +5060,6 @@
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
-    "mimic-response": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -5823,28 +5810,6 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
-    "prebuild-install": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.1.tgz",
-      "integrity": "sha512-lRLBU0JPXBbpC/ER9PtVYYk1y9Rme1WiMA3WKEQ4v78A5kTsqQtrEyYlbghvXCA6Uhr/769SkhibQznjDBRZpg==",
-      "requires": {
-        "detect-libc": "1.0.3",
-        "expand-template": "2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "napi-build-utils": "1.0.1",
-        "node-abi": "2.11.0",
-        "noop-logger": "0.1.1",
-        "npmlog": "4.1.2",
-        "pump": "3.0.0",
-        "rc": "1.2.8",
-        "simple-get": "3.0.3",
-        "tar-fs": "2.0.0",
-        "tunnel-agent": "0.6.0",
-        "which-pm-runs": "1.0.0"
-      }
-    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -6400,19 +6365,89 @@
       "dev": true
     },
     "sharp": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.23.0.tgz",
-      "integrity": "sha512-3+QlktTYDPO9CLmB3DUaBSj729ic3R9TO5Bz318F8WubUW10HR4os0Tm+GdYNcVg0layhMhP4Hf2SILwXVG2ig==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.23.1.tgz",
+      "integrity": "sha512-xt1SOwC5ewuqApBzKMFQ5VaRsC3GjOl1xklsnPNAAG7KWEAi50STFrVwjxFRe4puZ/59JU0QQqoFe7TZNnXd/g==",
       "requires": {
         "color": "3.1.2",
         "detect-libc": "1.0.3",
         "nan": "2.14.0",
         "npmlog": "4.1.2",
-        "prebuild-install": "5.3.1",
+        "prebuild-install": "5.3.2",
         "semver": "6.3.0",
-        "simple-get": "3.0.3",
-        "tar": "4.4.10",
+        "simple-get": "3.1.0",
+        "tar": "4.4.13",
         "tunnel-agent": "0.6.0"
+      },
+      "dependencies": {
+        "decompress-response": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+          "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+          "requires": {
+            "mimic-response": "2.0.0"
+          }
+        },
+        "mimic-response": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.0.0.tgz",
+          "integrity": "sha512-8ilDoEapqA4uQ3TwS0jakGONKXVJqpy+RpM+3b7pLdOjghCrEiGp9SRkFbUHAmZW9vdnrENWHjaweIoTIJExSQ=="
+        },
+        "minipass": {
+          "version": "2.8.6",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.8.6.tgz",
+          "integrity": "sha512-lFG7d6g3+/UaFDCOtqPiKAC9zngWWsQZl1g5q6gaONqrjq61SX2xFqXMleQiFVyDpYwa018E9hmlAFY22PCb+A==",
+          "requires": {
+            "safe-buffer": "5.2.0",
+            "yallist": "3.0.3"
+          }
+        },
+        "prebuild-install": {
+          "version": "5.3.2",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.2.tgz",
+          "integrity": "sha512-INDfXzTPnhT+WYQemqnAXlP7SvfiFMopMozSgXCZ+RDLb279gKfIuLk4o7PgEawLp3WrMgIYGBpkxpraROHsSA==",
+          "requires": {
+            "detect-libc": "1.0.3",
+            "expand-template": "2.0.3",
+            "github-from-package": "0.0.0",
+            "minimist": "1.2.0",
+            "mkdirp": "0.5.1",
+            "napi-build-utils": "1.0.1",
+            "node-abi": "2.11.0",
+            "noop-logger": "0.1.1",
+            "npmlog": "4.1.2",
+            "pump": "3.0.0",
+            "rc": "1.2.8",
+            "simple-get": "3.1.0",
+            "tar-fs": "2.0.0",
+            "tunnel-agent": "0.6.0",
+            "which-pm-runs": "1.0.0"
+          }
+        },
+        "simple-get": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
+          "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+          "requires": {
+            "decompress-response": "4.2.1",
+            "once": "1.4.0",
+            "simple-concat": "1.0.0"
+          }
+        },
+        "tar": {
+          "version": "4.4.13",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+          "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+          "requires": {
+            "chownr": "1.1.2",
+            "fs-minipass": "1.2.6",
+            "minipass": "2.8.6",
+            "minizlib": "1.2.1",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.2.0",
+            "yallist": "3.0.3"
+          }
+        }
       }
     },
     "shaven": {
@@ -6460,16 +6495,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
       "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
-    },
-    "simple-get": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.0.3.tgz",
-      "integrity": "sha512-Wvre/Jq5vgoz31Z9stYWPLn0PqRqmBDpFSdypAnHu5AvRVCYPRYGnvryNLiXu8GOBNDH82J2FRHUGMjjHUpXFw==",
-      "requires": {
-        "decompress-response": "3.3.0",
-        "once": "1.4.0",
-        "simple-concat": "1.0.0"
-      }
     },
     "simple-swizzle": {
       "version": "0.2.2",
@@ -6964,20 +6989,6 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
-    },
-    "tar": {
-      "version": "4.4.10",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
-      "integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
-      "requires": {
-        "chownr": "1.1.2",
-        "fs-minipass": "1.2.6",
-        "minipass": "2.5.1",
-        "minizlib": "1.2.1",
-        "mkdirp": "0.5.1",
-        "safe-buffer": "5.2.0",
-        "yallist": "3.0.3"
-      }
     },
     "tar-fs": {
       "version": "2.0.0",

--- a/lambda/ribbon-maker/package.json
+++ b/lambda/ribbon-maker/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "dependencies": "0.0.1",
-    "sharp": "^0.23.0"
+    "sharp": "^0.23.1"
   },
   "devDependencies": {
     "aws-sdk": "^2.527.0",

--- a/lambda/ribbon-maker/scripts/make-zip.sh
+++ b/lambda/ribbon-maker/scripts/make-zip.sh
@@ -4,6 +4,7 @@ rm -rf node_modules
 docker run -v "$PWD":/var/task lambci/lambda:build-nodejs8.10 npm install
 
 # Create the zip with just index.js and node_modules at the top level.
+rm -f ribbon-make.zip
 mkdir zip-contents
 cp index.js zip-contents
 mv node_modules zip-contents

--- a/lambda/s3-image-conversion/package-lock.json
+++ b/lambda/s3-image-conversion/package-lock.json
@@ -1899,14 +1899,6 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
-    "decompress-response": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-      "requires": {
-        "mimic-response": "1.0.1"
-      }
-    },
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
@@ -5054,11 +5046,6 @@
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
-    "mimic-response": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -5809,28 +5796,6 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
-    "prebuild-install": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.1.tgz",
-      "integrity": "sha512-lRLBU0JPXBbpC/ER9PtVYYk1y9Rme1WiMA3WKEQ4v78A5kTsqQtrEyYlbghvXCA6Uhr/769SkhibQznjDBRZpg==",
-      "requires": {
-        "detect-libc": "1.0.3",
-        "expand-template": "2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "napi-build-utils": "1.0.1",
-        "node-abi": "2.11.0",
-        "noop-logger": "0.1.1",
-        "npmlog": "4.1.2",
-        "pump": "3.0.0",
-        "rc": "1.2.8",
-        "simple-get": "3.0.3",
-        "tar-fs": "2.0.0",
-        "tunnel-agent": "0.6.0",
-        "which-pm-runs": "1.0.0"
-      }
-    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -6384,19 +6349,89 @@
       "dev": true
     },
     "sharp": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.23.0.tgz",
-      "integrity": "sha512-3+QlktTYDPO9CLmB3DUaBSj729ic3R9TO5Bz318F8WubUW10HR4os0Tm+GdYNcVg0layhMhP4Hf2SILwXVG2ig==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.23.1.tgz",
+      "integrity": "sha512-xt1SOwC5ewuqApBzKMFQ5VaRsC3GjOl1xklsnPNAAG7KWEAi50STFrVwjxFRe4puZ/59JU0QQqoFe7TZNnXd/g==",
       "requires": {
         "color": "3.1.2",
         "detect-libc": "1.0.3",
         "nan": "2.14.0",
         "npmlog": "4.1.2",
-        "prebuild-install": "5.3.1",
+        "prebuild-install": "5.3.2",
         "semver": "6.3.0",
-        "simple-get": "3.0.3",
-        "tar": "4.4.10",
+        "simple-get": "3.1.0",
+        "tar": "4.4.13",
         "tunnel-agent": "0.6.0"
+      },
+      "dependencies": {
+        "decompress-response": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+          "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+          "requires": {
+            "mimic-response": "2.0.0"
+          }
+        },
+        "mimic-response": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.0.0.tgz",
+          "integrity": "sha512-8ilDoEapqA4uQ3TwS0jakGONKXVJqpy+RpM+3b7pLdOjghCrEiGp9SRkFbUHAmZW9vdnrENWHjaweIoTIJExSQ=="
+        },
+        "minipass": {
+          "version": "2.8.6",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.8.6.tgz",
+          "integrity": "sha512-lFG7d6g3+/UaFDCOtqPiKAC9zngWWsQZl1g5q6gaONqrjq61SX2xFqXMleQiFVyDpYwa018E9hmlAFY22PCb+A==",
+          "requires": {
+            "safe-buffer": "5.2.0",
+            "yallist": "3.0.3"
+          }
+        },
+        "prebuild-install": {
+          "version": "5.3.2",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.2.tgz",
+          "integrity": "sha512-INDfXzTPnhT+WYQemqnAXlP7SvfiFMopMozSgXCZ+RDLb279gKfIuLk4o7PgEawLp3WrMgIYGBpkxpraROHsSA==",
+          "requires": {
+            "detect-libc": "1.0.3",
+            "expand-template": "2.0.3",
+            "github-from-package": "0.0.0",
+            "minimist": "1.2.0",
+            "mkdirp": "0.5.1",
+            "napi-build-utils": "1.0.1",
+            "node-abi": "2.11.0",
+            "noop-logger": "0.1.1",
+            "npmlog": "4.1.2",
+            "pump": "3.0.0",
+            "rc": "1.2.8",
+            "simple-get": "3.1.0",
+            "tar-fs": "2.0.0",
+            "tunnel-agent": "0.6.0",
+            "which-pm-runs": "1.0.0"
+          }
+        },
+        "simple-get": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
+          "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+          "requires": {
+            "decompress-response": "4.2.1",
+            "once": "1.4.0",
+            "simple-concat": "1.0.0"
+          }
+        },
+        "tar": {
+          "version": "4.4.13",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+          "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+          "requires": {
+            "chownr": "1.1.2",
+            "fs-minipass": "1.2.6",
+            "minipass": "2.8.6",
+            "minizlib": "1.2.1",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.2.0",
+            "yallist": "3.0.3"
+          }
+        }
       }
     },
     "shaven": {
@@ -6444,16 +6479,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
       "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
-    },
-    "simple-get": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.0.3.tgz",
-      "integrity": "sha512-Wvre/Jq5vgoz31Z9stYWPLn0PqRqmBDpFSdypAnHu5AvRVCYPRYGnvryNLiXu8GOBNDH82J2FRHUGMjjHUpXFw==",
-      "requires": {
-        "decompress-response": "3.3.0",
-        "once": "1.4.0",
-        "simple-concat": "1.0.0"
-      }
     },
     "simple-swizzle": {
       "version": "0.2.2",
@@ -6948,20 +6973,6 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
-    },
-    "tar": {
-      "version": "4.4.10",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
-      "integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
-      "requires": {
-        "chownr": "1.1.2",
-        "fs-minipass": "1.2.6",
-        "minipass": "2.5.1",
-        "minizlib": "1.2.1",
-        "mkdirp": "0.5.1",
-        "safe-buffer": "5.2.0",
-        "yallist": "3.0.3"
-      }
     },
     "tar-fs": {
       "version": "2.0.0",

--- a/lambda/s3-image-conversion/package.json
+++ b/lambda/s3-image-conversion/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "aws-sdk": "^2.527.0",
     "dependencies": "0.0.1",
-    "sharp": "^0.23.0"
+    "sharp": "^0.23.1"
   },
   "devDependencies": {
     "bespoken-tools": "^2.4.6"

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,6 @@
                  [re-frame "0.10.6"]
                  [cljs-ajax "0.8.0"]
                  [day8.re-frame/http-fx "0.1.6"]
-                 [joda-time "2.10.1"]
                  [amazonica "0.3.134" :exclusions [com.amazonaws/aws-java-sdk
                                                    com.amazonaws/amazon-kinesis-client]]
                  [com.amazonaws/aws-java-sdk-core "1.11.452"]
@@ -20,7 +19,7 @@
                  [org.clojure/core.async "0.4.474"]
                  [danlentz/clj-uuid "0.1.7"]
                  [com.lucasbradstreet/cljs-uuid-utils "1.0.2"]
-                 [clj-time "0.15.1"]
+                 [clojure.java-time "0.3.2"]
                  [com.andrewmcveigh/cljs-time "0.5.2"]
                  [re-com "2.4.0"]
                  [compojure "1.6.1"]

--- a/src/clj/helodali/db.clj
+++ b/src/clj/helodali/db.clj
@@ -2,16 +2,13 @@
   (:require [taoensso.faraday :as far]
             [clojure.string :as str]
             [clj-uuid :as uuid]
-            [clj-time.core :refer [now year days ago]]
-            [clj-time.format :refer [parse unparse formatters]]
+            [java-time :as jt]
             [helodali.types :as types]
             [clojure.java.io :as io]
-            [helodali.common :refer [log coerce-int coerce-decimal-string fix-date keywordize-vals]]
+            [helodali.common :refer [log coerce-int coerce-decimal-string keywordize-vals]]
             [clojure.pprint :refer [pprint]]
             [helodali.s3 :as s3])
-  (:import [java.time ZonedDateTime ZoneId]
-           (java.time.format DateTimeFormatter)
-           (com.amazonaws.services.dynamodbv2.model ConditionalCheckFailedException)))
+  (:import (com.amazonaws.services.dynamodbv2.model ConditionalCheckFailedException)))
 
 ;; These environment variables are only necessary when running the app locally
 ;; or outside AWS. Within AWS, we assign an IAM role to the ElasticBeanstalk
@@ -179,7 +176,7 @@
 (defn- filter-out-empty
   [in]
   (cond
-    (map? in) (into {} (filter (fn [[k v]]
+    (map? in) (into {} (filter (fn [[_ v]]
                                 (if (or (nil? v) (and (string? v) (empty? v)) (and (coll? v) (empty? v)))
                                  false
                                  true)) in))
@@ -220,7 +217,7 @@
     (log "Performing change" change)
     (try
       (far/update-item co table primary-key-map change)
-      (catch ConditionalCheckFailedException e (do (pprint "Attempt to update a non-existing item.")
+      (catch ConditionalCheckFailedException _ (do (pprint "Attempt to update a non-existing item.")
                                                    {}))
       (catch Exception e (do (log "Unable to update item" e)
                              {}))))) ;; TODO: Need to respond with error to client.
@@ -274,7 +271,7 @@
       (log "No changes to apply for" changes)
       (try
         (far/update-item co table primary-key-map db-changes)
-        (catch ConditionalCheckFailedException e (do (pprint "Attempt to update a non-existing item.")
+        (catch ConditionalCheckFailedException _ (do (pprint "Attempt to update a non-existing item.")
                                                      {}))
         (catch Exception e (do (log "Unable to apply updates to item" e)
                                {})))))) ;; TODO: Need to respond with error to client.
@@ -371,7 +368,7 @@
         dimensions-matched (re-find #"(?i)[^\d]*(\d+[\"\']?\s*[xXby]+\s*\d+[\"\']?\s*(inches|in|feet|ft|cm|meters|m)?)" caption)
         year (if year-matched
                (Integer/parseInt (str/trim (second year-matched)))
-               (year (now)))
+               (jt/as (jt/local-date) :year))
         item (cond-> {:uref uref
                       :uuid artwork-uuid
                       :created (:created media)
@@ -423,7 +420,7 @@
     (let [openid-item (far/get-item co :openid {:sub (:sub userinfo)})]
       (if (nil? (:uref openid-item))
         (let [uuid (str (uuid/v1))
-              created (unparse (formatters :date) (now))
+              created (jt/format "yyyy-MM-dd" (jt/zoned-date-time))
               ;; Use name from external IdP or username from Cognito native accounts
               name-or-username (or (:cognito:username userinfo) (:name userinfo))]
           (pprint (str "Creating user account for " (:sub userinfo)))
@@ -441,12 +438,12 @@
   (let [openid-item (far/get-item co :openid {:sub (:sub userinfo)})
         uref (:uref openid-item)]
     (when uref
-      (let [tn (ZonedDateTime/now (ZoneId/of "Z"))]
+      (let [tn (jt/with-zone (jt/zoned-date-time) "UTC")]
         (far/put-item co :sessions {:uuid     session-uuid :uref uref :token (:access_token token-resp)
                                     :refresh  (:refresh_token token-resp)
                                     :id-token (:id_token token-resp) :sub (:sub userinfo)
                                     :expire-at (+ session-expiration-seconds (.getEpochSecond (.toInstant tn)))
-                                    :ts (.format tn DateTimeFormatter/ISO_INSTANT)})
+                                    :ts (jt/format tn)})
         uref))))
 
 (defn query-session

--- a/src/clj/helodali/instagram.clj
+++ b/src/clj/helodali/instagram.clj
@@ -4,9 +4,6 @@
             [clojure.java.io :as io]
             [clojure.pprint :refer [pprint]]
             [slingshot.slingshot :refer [throw+ try+]]
-            [clj-time.core :refer [now days ago]]
-            [clj-time.format :refer [parse unparse formatters]]
-            [helodali.common :refer [coerce-int fix-date keywordize-vals]]
             [helodali.db :refer [get-account query-by-uref update-user-table]])
   (:import (javax.crypto Mac)
            (javax.crypto.spec SecretKeySpec)))

--- a/src/cljc/helodali/common.cljc
+++ b/src/cljc/helodali/common.cljc
@@ -2,11 +2,7 @@
   (:require [clojure.pprint :refer [pprint]]
             #?(:cljs [cljs.reader :as cljsr])
             #?(:clj  [clj-uuid :as uuid]
-               :cljs [cljs-uuid-utils.core :as uuid])
-            #?(:clj  [clj-time.core :refer [now days ago date-time]]
-               :cljs [cljs-time.core :refer [now days ago date-time]])
-            #?(:clj  [clj-time.format :refer [parse unparse formatters]]
-               :cljs [cljs-time.format :refer [parse unparse formatters]])))
+               :cljs [cljs-uuid-utils.core :as uuid])))
 
 (defn coerce-int
   "Given map and set of keys, coerce the values associated with keys to int
@@ -39,43 +35,12 @@
     nil
     v))
 
-(defn fix-date
-  "Called with a map or a vector of maps, such as an artwork's :purchases, converts a date valued kw to/from string
-   The type argument is a keyword of either :parse or :unparse."
-  [type kw v-or-m]
-  (let [parse-unparse (if (= type :parse)
-                        parse
-                        unparse)
-        fix-date-key-val #(if-let [kw-val (get % kw)]
-                            (assoc % kw (parse-unparse (formatters :date) kw-val))
-                            %)]
-    (if (map? v-or-m)
-      (fix-date-key-val v-or-m)
-      (mapv fix-date-key-val v-or-m))))
-
 (defn keywordize-vals
   "Given map and set of keys, convert the values associated with keys to keyword.
    E.g. {:role \"person\"} => {:role :person}"
   [m ks]
   (let [ks (set ks)]
     (into {} (map (fn [[k, v]] (if (contains? ks k) [k, (keyword v)] [k, v])) m))))
-
-(defn parse-date
-  "Called with timestamp and converted to clj(s) object"
-  [format-kw ts]
-  (if (not-empty ts)
-    (parse (formatters format-kw) ts)
-    nil))
-
-(defn unparse-date
-  "Called with clj-time or cljs-time object, convert to string"
-  [d]
-  (unparse (formatters :date) d))
-
-(defn unparse-datetime
-  "Called with clj-time or cljs-time object, convert to string"
-  [d]
-  (unparse (formatters :date-time) d))
 
 (defn log
   [message data]

--- a/src/cljs/helodali/events.cljs
+++ b/src/cljs/helodali/events.cljs
@@ -1,10 +1,11 @@
 (ns helodali.events
   (:require
     [ajax.core :as ajax]
-    [helodali.common :refer [coerce-int coerce-decimal empty-string-to-nil fix-date parse-date unparse-date unparse-datetime]]
+    [helodali.common :refer [coerce-int coerce-decimal empty-string-to-nil]]
     [helodali.spec :as hs] ;; Keep this here even though we refer to the namespace directly below
     [helodali.misc :refer [expired? generate-uuid find-element-by-key-value find-item-by-key-value
-                           remove-vector-element into-sorted-map trunc search-item-by-key-value]]
+                           remove-vector-element into-sorted-map trunc search-item-by-key-value
+                           fix-date parse-date unparse-date unparse-datetime]]
     [helodali.routes :refer [route]]
     [helodali.db :refer [s3-key-for-bucket]]
     [cljs-time.core :as ct]

--- a/src/cljs/helodali/misc.cljs
+++ b/src/cljs/helodali/misc.cljs
@@ -30,6 +30,37 @@
       (let [dt (parse (formatters :date-time) ts)]
         (before? dt (now))))))
 
+(defn fix-date
+  "Called with a map or a vector of maps, such as an artwork's :purchases, converts a date valued kw to/from string
+   The type argument is a keyword of either :parse or :unparse."
+  [type kw v-or-m]
+  (let [parse-unparse (if (= type :parse)
+                        parse
+                        unparse)
+        fix-date-key-val #(if-let [kw-val (get % kw)]
+                            (assoc % kw (parse-unparse (formatters :date) kw-val))
+                            %)]
+    (if (map? v-or-m)
+      (fix-date-key-val v-or-m)
+      (mapv fix-date-key-val v-or-m))))
+
+(defn parse-date
+  "Called with timestamp and converted to clj(s) object"
+  [format-kw ts]
+  (if (not-empty ts)
+    (parse (formatters format-kw) ts)
+    nil))
+
+(defn unparse-date
+  "Called with cljs-time object, convert to string"
+  [d]
+  (unparse (formatters :date) d))
+
+(defn unparse-datetime
+  "Called with cljs-time object, convert to string"
+  [d]
+  (unparse (formatters :date-time) d))
+
 (defn find-element-by-key-value
   "Given a list of maps, return the index into the vector where the given key
    and value match. E.g. find the image with :uuid 1234"


### PR DESCRIPTION

- Sharp has replaced .crop and .overlay methods with equivalent options to .resize and .composite
- Migrate from clj-time to java-time on the server (no more joda-time involved)
- Introduce expire-at attribute on session table to be used as a DynamoDB ttl attribute to expunge items