### PR TITLE
Fix server response edge cases

### DIFF
--- a/src/clj/helodali/db.clj
+++ b/src/clj/helodali/db.clj
@@ -110,7 +110,6 @@
   "Delete everything except for portions of the :accounts needed for later processes
    (e.g. cleanup of public-pages feature)."
   [uref sub]
-  ; TODO: Trigger account removal
   (let [query-opts {:proj-expr "#uref, #uuid"
                     :expr-attr-names {"#uref" "uref" "#uuid" "uuid"}}]
     (delete-items :artwork (far/query co :artwork {:uref [:eq uref]} query-opts))
@@ -121,6 +120,7 @@
     (delete-items :press (far/query co :press {:uref [:eq uref]} query-opts))
     (delete-item :profiles {:uuid uref})
     (delete-item :pages {:uuid uref})
+    (delete-item :accounts {:uuid uref})
     (delete-item :openid {:sub sub})))
 
 

--- a/src/clj/helodali/handler.clj
+++ b/src/clj/helodali/handler.clj
@@ -175,13 +175,13 @@
         (db/delete-item :sessions (select-keys session [:uuid]))
         ;; Delete all items in DynamoDB associated with the user
         (db/delete-user uref (:sub session))
+        ;; TODO: Confirm that the above deletion of the user's :pages item results in a site removal
         ;; Delete all s3 objects (removing helodali-raw-images will trigger the lambda function to
         ;; remove the associated helodali-images object)
         (when (not (empty? (:sub session)))
           ;; Making sure the prefix to s3/delete-objects is not nil
           (s3/delete-objects-by-prefix :helodali-raw-images (:sub session))
           (s3/delete-objects-by-prefix :helodali-documents (:sub session))))
-          ; TODO: Remove public pages
       (-> (response {})
         ;; Clear the user's information in the session cookie
         (assoc :session (vary-meta session-cookie assoc :recreate true)))))

--- a/src/cljs/helodali/views/artwork.cljs
+++ b/src/cljs/helodali/views/artwork.cljs
@@ -283,7 +283,7 @@
                                   :children (into [] (mapv (fn [idx image bg] ^{:key (str "image-" idx)} [display-secondary-image id editing idx image bg]) (range 1 (count @images)) (rest @images) (cycle [true false])))])]]
             create-control [h-box :gap "20px" :justify :center :align :center :margin "14px" :style {:font-size "18px"}
                               :children [[button :label "Create" :class "btn-default"
-                                           :on-click #(dispatch [:create-from-placeholder :artwork []])]
+                                           :on-click #(dispatch [:create-from-placeholder :artwork])]
                                          [button :label "Cancel" :class "btn-default"
                                            :on-click #(dispatch [:delete-item :artwork id])]]]
             save-control [h-box :gap "20px" :justify :center :align :center :margin "14px" :style {:font-size "18px"}

--- a/src/cljs/helodali/views/contacts.cljs
+++ b/src/cljs/helodali/views/contacts.cljs
@@ -78,7 +78,7 @@
             view-box [v-box :gap "10px" :align :start :justify :start :children view]
             create-control [h-box :gap "30px" :align :center
                               :children [[button :label "Create" :class "btn-default"
-                                           :on-click #(dispatch [:create-from-placeholder :contacts [:name]])]
+                                           :on-click #(dispatch [:create-from-placeholder :contacts])]
                                          [button :label "Cancel" :class "btn-default"
                                            :on-click #(dispatch [:delete-item :contacts id])]]]
             save-control [h-box :gap "20px" :justify :center :align :center :margin "14px" :style {:font-size "18px"}

--- a/src/cljs/helodali/views/documents.cljs
+++ b/src/cljs/helodali/views/documents.cljs
@@ -61,7 +61,7 @@
                                        [:pre @notes]]])]
             create-control [h-box :gap "30px" :align :center
                               :children [[button :label "Create" :class "btn-default"
-                                           :on-click #(dispatch [:create-from-placeholder :documents []])]
+                                           :on-click #(dispatch [:create-from-placeholder :documents])]
                                          [button :label "Cancel" :class "btn-default"
                                            :on-click #(dispatch [:delete-item :documents id])]]]
             save-control [h-box :gap "20px" :justify :center :align :center :margin "14px" :style {:font-size "18px"}

--- a/src/cljs/helodali/views/exhibitions.cljs
+++ b/src/cljs/helodali/views/exhibitions.cljs
@@ -114,7 +114,7 @@
                                        [:pre @notes]]])]
             create-control [h-box :gap "30px" :align :center
                               :children [[button :label "Create" :class "btn-default"
-                                           :on-click #(dispatch [:create-from-placeholder :exhibitions []])]
+                                           :on-click #(dispatch [:create-from-placeholder :exhibitions])]
                                          [button :label "Cancel" :class "btn-default"
                                            :on-click #(dispatch [:delete-item :exhibitions id])]]]
             save-control [h-box :gap "20px" :justify :center :align :center :margin "14px" :style {:font-size "18px"}

--- a/src/cljs/helodali/views/expenses.cljs
+++ b/src/cljs/helodali/views/expenses.cljs
@@ -54,7 +54,7 @@
             view-box [v-box :gap "10px" :align :start :justify :start :children view]
             create-control [h-box :gap "30px" :align :center
                               :children [[button :label "Create" :class "btn-default"
-                                           :on-click #(dispatch [:create-from-placeholder :expenses []])]
+                                           :on-click #(dispatch [:create-from-placeholder :expenses])]
                                          [button :label "Cancel" :class "btn-default"
                                            :on-click #(dispatch [:delete-item :expenses id])]]]
             save-control [h-box :gap "20px" :justify :center :align :center :margin "14px" :style {:font-size "18px"}

--- a/src/cljs/helodali/views/press.cljs
+++ b/src/cljs/helodali/views/press.cljs
@@ -89,7 +89,7 @@
                                        [:pre @notes]]])]
             create-control [h-box :gap "30px" :align :center
                               :children [[button :label "Create" :class "btn-default"
-                                           :on-click #(dispatch [:create-from-placeholder :press []])]
+                                           :on-click #(dispatch [:create-from-placeholder :press])]
                                          [button :label "Cancel" :class "btn-default"
                                            :on-click #(dispatch [:delete-item :press id])]]]
             save-control [h-box :gap "20px" :justify :center :align :center :margin "14px" :style {:font-size "18px"}


### PR DESCRIPTION
- When responding to a client request, the response did not always merge in unsolicited token updates properly.
- Fix a regression in caching the access token.
- Improve the handling of s3 getSignedUrl event dispatch, using pure functions as recommended by re-frame.